### PR TITLE
Inherit secrets when calling .NET Build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,3 +12,4 @@ jobs:
       build-config: 'Release'
       artifact-folder: 'NuGet'
       nuget-push: true
+    secrets: inherit


### PR DESCRIPTION
When using reusable workflows the secrets are not available to the `called` workflow unless they are passed from the `caller`.

See [Simplify using secrets with reusable workflows](https://github.blog/changelog/2022-05-03-github-actions-simplify-using-secrets-with-reusable-workflows/) for a simple way.