### PR TITLE
Add unit tests to increase code coverage

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,8 +22,8 @@ on:
         description: Build configuration
         type: string
         default: Release
-      artifact-folder:
-        description: Folder for any artifacts
+      artifact-name:
+        description: Name for any artifacts
         type: string
         default: ""
       nuget-push:
@@ -56,8 +56,8 @@ on:
         - Debug
         - Release
         default: Debug
-      artifact-folder:
-        description: Folder for any artifacts
+      artifact-name:
+        description: Name for any artifacts
         type: string
         default: ""
       nuget-push:
@@ -68,9 +68,9 @@ on:
 run-name: ${{ inputs.run-name }}
 
 env:
-  ARTIFACT_PATH: ${{ github.workspace }}/${{ inputs.artifact-folder }}
-  DOTNET_PACK: ${{ inputs.artifact-folder != '' }}
-  NUGET-PUSH: ${{ inputs.artifact-folder != '' && inputs.nuget-push }}
+  ARTIFACT_PATH: ${{ github.workspace }}/upload
+  DOTNET_PACK: ${{ inputs.artifact-name != '' }}
+  NUGET-PUSH: ${{ inputs.artifact-name != '' && inputs.nuget-push }}
 
 jobs:
 
@@ -111,7 +111,7 @@ jobs:
         if: env.DOTNET_PACK == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-${{ inputs.artifact-folder }}
+          name: ${{ github.event.repository.name }}-${{ inputs.artifact-name }}
           path: ${{ env.ARTIFACT_PATH }}
           retention-days: 10
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -93,7 +93,8 @@ jobs:
 
       - name: Create artifacts folder
         if: env.DOTNET_PACK == 'true'
-        run: mkdir ${{ env.ARTIFACT_PATH }}
+        shell: pwsh
+        run: mkdir ${{ env.ARTIFACT_PATH }} > $null
 
       - name: .NET Restore
         run: dotnet restore /property:Configuration=${{ inputs.build-config }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,7 +10,3 @@ jobs:
   Merge:
     if: github.event.pull_request.merged == true
     uses: ./.github/workflows/dotnet.yml # In same repository, uses file from same commit as the calling workflow
-    with:
-      build-config: 'Release'
-      artifact-folder: ""
-      nuget-push: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,6 @@ jobs:
   Publish:
     uses: ./.github/workflows/dotnet.yml # In same repository, uses file from same commit as the calling workflow
     with:
-      build-config: 'Release'
-      artifact-folder: 'NuGet'
+      artifact-name: 'NuGet'
       nuget-push: true
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,6 @@ jobs:
   Publish:
     uses: ./.github/workflows/dotnet.yml # In same repository, uses file from same commit as the calling workflow
     with:
-      artifact-name: 'NuGet'
+      artifact-name: 'Publish'
       nuget-push: true
     secrets: inherit

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -15,15 +15,11 @@ on:
         - ubuntu-latest
         - windows-latest
         default: ubuntu-latest
-      artifact-folder:
-        description: Folder for any artifacts
-        type: string
-        default: UnitTests
 
 run-name: ${{ inputs.run-name }}
 
 env:
-  ARTIFACT_PATH: ${{ github.workspace }}/${{ inputs.artifact-folder }}
+  ARTIFACT_PATH: ${{ github.workspace }}/upload
 
 jobs:
 
@@ -42,7 +38,6 @@ jobs:
       #     dotnet-version: 8.0.x
 
       - name: Create artifacts folder
-        if: ${{ inputs.artifact-folder != '' }}
         run: mkdir ${{ env.ARTIFACT_PATH }}
 
       - name: .NET Restore
@@ -53,7 +48,6 @@ jobs:
         run: .\tests\RunTests.ps1 ${{ env.ARTIFACT_PATH }}
 
       - name: Generate reports
-        if: ${{ inputs.artifact-folder != '' }}
         env:
           PROJECT_NAME: "xunittestproject"
         uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
@@ -68,9 +62,8 @@ jobs:
           toolpath: 'reportgeneratortool'
 
       - name: Upload artifacts
-        if: ${{ inputs.artifact-folder != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-${{ inputs.artifact-folder }}
+          name: ${{ github.event.repository.name }}-TestResults
           path: ${{ env.ARTIFACT_PATH }}
           retention-days: 5

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -14,7 +14,7 @@ on:
         options: 
         - ubuntu-latest
         - windows-latest
-        default: ubuntu-latest
+        default: windows-latest
 
 run-name: ${{ inputs.run-name }}
 
@@ -24,7 +24,7 @@ env:
 jobs:
 
   unit-tests:
-    name: Unit Tests
+    name: UnitTests
     runs-on: ${{ inputs.runs-on }}
 
     steps:
@@ -38,7 +38,8 @@ jobs:
       #     dotnet-version: 8.0.x
 
       - name: Create artifacts folder
-        run: mkdir ${{ env.ARTIFACT_PATH }}
+        shell: pwsh
+        run: mkdir ${{ env.ARTIFACT_PATH }} > $null
 
       - name: .NET Restore
         run: dotnet restore /property:Configuration=Debug
@@ -64,6 +65,6 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-TestResults
+          name: ${{ github.event.repository.name }}-UnitTests
           path: ${{ env.ARTIFACT_PATH }}
           retention-days: 5

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@
 [![git-hub-actions-workflow-status](https://img.shields.io/github/actions/workflow/status/kevindheath/samples/publish.yml?style=plastic&label=%F0%9F%93%A6%20Publish%20Packages)](https://github.com/kevindheath/samples/actions/workflows/publish.yml)
 
 The documentation for this repository can be found on the 
-_[Wiki pages.](https://github.com/kevindheath/samples/wiki/Home)_
+_[Wiki.](https://github.com/kevindheath/samples/wiki/Home)_

--- a/Samples.sln
+++ b/Samples.sln
@@ -26,6 +26,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{07E20368-EB81-4069-BDC7-A67F101D4556}"
 	ProjectSection(SolutionItems) = preProject
 		tests\RunTests.ps1 = tests\RunTests.ps1
+		tests\.runsettings = tests\.runsettings
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xUnitTestProject", "tests\xUnitTestProject\xUnitTestProject.csproj", "{908DF14B-92AF-42DC-9B45-632038B93D96}"

--- a/src/ClassLibrary/Services/BaseService.cs
+++ b/src/ClassLibrary/Services/BaseService.cs
@@ -27,20 +27,17 @@ public abstract class BaseService
 
 	private static List<T> DeserializeList<T>( ref string? json, JsonSerializerOptions? options = null )
 	{
-		if( json is not null )
+		List<T> rtn = [];
+		json ??= string.Empty;
+		options ??= DefaultSerializerOptions();
+		try
 		{
-			options ??= DefaultSerializerOptions();
-			try
-			{
-				List<T>? obj = JsonSerializer.Deserialize<List<T>>( json, options );
-				if( obj is not null ) { return obj; }
-			}
-			catch( ArgumentException ) { }
-			catch( JsonException ) { }
-			catch( NotSupportedException ) { }
+			List<T>? obj = JsonSerializer.Deserialize<List<T>>( json, options );
+			if( obj is not null ) { rtn = obj; }
 		}
+		catch( Exception ) { }
 
-		return [];
+		return rtn;
 	}
 
 	private static JsonSerializerOptions DefaultSerializerOptions()

--- a/tests/.runsettings
+++ b/tests/.runsettings
@@ -1,16 +1,10 @@
+<!-- https://learn.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file -->
 <RunSettings>
-  <!-- https://learn.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file -->
 
   <!-- Configurations that affect the Test Framework -->
   <RunConfiguration>
-    <ResultsDirectory>.\TestResults</ResultsDirectory>
+    <ResultsDirectory>.\tests\TestResults</ResultsDirectory>
   </RunConfiguration>
-
-  <!--<DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="XPlat Code Coverage"/>
-    </DataCollectors>
-   </DataCollectionRunSettings>-->
 
   <!-- Configuration for loggers -->
   <LoggerRunSettings>
@@ -24,7 +18,18 @@
     </Loggers>
   </LoggerRunSettings>
 
-  <!-- Adapter Specific sections -->
+  <!-- https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/VSTestIntegration.md -->
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+
+  <!-- https://xunit.net/docs/runsettings -->
   <xUnit>
     <MethodDisplay>method</MethodDisplay>
     <MethodDisplayOptions>replaceUnderscoreWithSpace,useOperatorMonikers</MethodDisplayOptions>

--- a/tests/RunTests.ps1
+++ b/tests/RunTests.ps1
@@ -6,13 +6,15 @@ function DotNet_Test {
   $results = "$output\TestResults\" + $testProject.split('.')[0].ToLower()
   $history = "$results\history"
 
-  # Build projects and run unit tests
+  # Build project
   Push-Location "$PSScriptRoot\$testProject"
   if( "$PSScriptRoot" -eq "$output" ) { dotnet clean | Out-Null }
   dotnet build --no-restore -c Debug
   if( $LASTEXITCODE -gt 0 ) { Pop-Location; exit 1 }
+
+  # Run unit tests
   if( Test-Path "$results" ) { Remove-Item -Path "$results\*" -Recurse | Out-Null }
-  dotnet test --settings unittest.runsettings --collect:"XPlat Code Coverage" --no-build --results-directory "$results"
+  dotnet test --settings "$PSScriptRoot\.runsettings" --no-build --results-directory "$results"
   Pop-Location
 
   # Copy the oldest 3 history files
@@ -22,13 +24,13 @@ function DotNet_Test {
     foreach( $file in ( Get-ChildItem "$wrk" -Filter *.xml | Sort-Object -Property FullName | Select-Object -First 3 ) )
     { Copy-Item -Path "$file" -Destination "$history" }
   }
+
   # If running locally generate reports
   if( "$PSScriptRoot" -eq "$output" ) {
     $reports = "$results\*\coverage.cobertura.xml"
     $rpTypes = "-reporttypes:Html;Badges;MarkdownSummaryGithub"
     $setting = "--settings:createSubdirectoryForAllReportTypes=true"
     $title = "-title:$testProject"
-
     Write-Host "Generating coverage reports for $testProject" -ForegroundColor Yellow
     reportgenerator -reports:"$reports" -targetdir:"$results\reports" -historydir:$history $title -verbosity:Warning $rpTypes $setting
   }

--- a/tests/xUnitTestProject/MovieReviewServiceTests.cs
+++ b/tests/xUnitTestProject/MovieReviewServiceTests.cs
@@ -1,0 +1,41 @@
+﻿using ClassLibrary.Models;
+using ClassLibrary.Services;
+
+namespace xUnitTestProject;
+
+public class MovieReviewServiceTests
+{
+	[Fact]
+	public async Task MovieReviewService_Get_Should_Return_Count_gt_0()
+	{
+		// Arrange
+		MovieReviewService service = new();
+
+		// Act (with code coverage)
+		List<Movie> result = await service.GetMovies();
+		if( result.Count > 0 ) { _ = service.GetMovie( result[0].Id ); }
+
+		// Assert
+		result.Count.Should().BeGreaterThan( 0 );
+	}
+
+	[Fact]
+	public void MovieReview_Should_Have_Value()
+	{
+		// Arrange
+		int id = 1;
+		int movieId = 1;
+		var title = "New Movie";
+		var review = "Rotten tomatoes";
+
+		// Act (with code coverage)
+		MovieReview result = new() { Id = id, MovieId = movieId, Title = title, Review = review };
+		id = result.Id;
+		movieId = result.MovieId;
+		title = result.Title;
+		review = result.Review;
+
+		// Assert
+		result.Should().BeOfType( typeof( MovieReview ) );
+	}
+}

--- a/tests/xUnitTestProject/Testdata/history/2024-03-23_20-28-57_CoverageHistory.xml
+++ b/tests/xUnitTestProject/Testdata/history/2024-03-23_20-28-57_CoverageHistory.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<coverage version="1.0" date="2024-03-23_20-28-57" tag="7_8404309973">
+  <assembly name="ClassLibrary">
+    <class name="ClassLibrary.BaseService" coveredlines="34" coverablelines="35" totallines="58" coveredbranches="9" totalbranches="14" coveredcodeelements="4" totalcodeelements="4" />
+    <class name="ClassLibrary.Models.Movie" coveredlines="5" coverablelines="5" totallines="14" coveredbranches="0" totalbranches="0" coveredcodeelements="5" totalcodeelements="5" />
+    <class name="ClassLibrary.Models.MovieReview" coveredlines="4" coverablelines="4" totallines="12" coveredbranches="0" totalbranches="0" coveredcodeelements="4" totalcodeelements="4" />
+    <class name="ClassLibrary.Models.WeatherForecast" coveredlines="5" coverablelines="5" totallines="14" coveredbranches="0" totalbranches="0" coveredcodeelements="5" totalcodeelements="5" />
+    <class name="ClassLibrary.Services.MovieReviewService" coveredlines="6" coverablelines="6" totallines="14" coveredbranches="2" totalbranches="2" coveredcodeelements="3" totalcodeelements="3" />
+    <class name="ClassLibrary.Services.WeatherForecastService" coveredlines="20" coverablelines="20" totallines="29" coveredbranches="0" totalbranches="0" coveredcodeelements="3" totalcodeelements="3" />
+    <class name="ClassLibrary.Services.WeatherForecastServiceEx" coveredlines="3" coverablelines="3" totallines="9" coveredbranches="0" totalbranches="0" coveredcodeelements="1" totalcodeelements="1" />
+    <class name="ClassLibrary.WeatherCalculator" coveredlines="12" coverablelines="12" totallines="26" coveredbranches="10" totalbranches="10" coveredcodeelements="2" totalcodeelements="2" />
+  </assembly>
+</coverage>

--- a/tests/xUnitTestProject/WeatherForecastServiceTests.cs
+++ b/tests/xUnitTestProject/WeatherForecastServiceTests.cs
@@ -1,0 +1,33 @@
+﻿using ClassLibrary.Services;
+
+namespace xUnitTestProject;
+
+public class WeatherForecastServiceTests
+{
+	[Fact]
+	public void WeatherForecastService_Get_Should_Return_5()
+	{
+		// Arrange
+		WeatherForecastService service = new();
+
+		// Act (with code coverage)
+		var result = service.Get().ToList();
+		if( result.Count > 0 ) { _ = result[0].TemperatureF; }
+
+		// Assert
+		result.Should().HaveCount( 5 );
+	}
+
+	[Fact]
+	public void WeatherForecastServiceEx_Get_Should_Return_15()
+	{
+		// Arrange
+		WeatherForecastServiceEx service = new();
+
+		// Act
+		var result = service.Get();
+
+		// Assert
+		result.Should().HaveCount( 15 );
+	}
+}


### PR DESCRIPTION
The code coverage is increased to reduce the metric thresholds.

Also:
- The workflows have been updated to standardize the artifact names 
- The `artifact-folder` value is now hard-coded as `upload` in all workflows to avoid using an existing folder name
- The `artifact-folder` input in the .NET Build workflow is now called `artifact-name`
- The `artifact-folder` input has been removed from the Run Tests workflow as the artifact is now always named `UnitTests`
- All the default input values are now used by the Pull Request Merge workflow
- The Publish Packages workflow now uses the `secrets-inherit` keyword when calling .NET Build so that the NuGet Push step has access to the authorization token
- The default `runs-on` input for the Run Tests workflow has been changed to `windows-latest` due to using a `json` file to populate the movie reviews entity
